### PR TITLE
fix: body background in dark-mode

### DIFF
--- a/src/css/app.css
+++ b/src/css/app.css
@@ -3,3 +3,12 @@
 *::after {
   @apply border-gray-200;
 }
+
+/* 
+* Set the global background  
+* Avoids a glitch on mobile devices when scrolling to fast
+*/
+
+body.darkmode--activated {
+  background: #000000;
+}


### PR DESCRIPTION
Set the global background
attempts to fix the colour glitch on mobile devices when
scrolling to fast

#### Note 
You may or may not need this fix